### PR TITLE
Breaking: do not implicitly call parent constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ err.code;    //=> 404
 
 ## Custom Constructors
 
-A custom constructor can be passed to `subclass`, which will be called
-after all super-constructors.
+A custom constructor can be passed to `subclass`, which will hide
+all super constructors. If you want to propagate arguments
+to the parent constructor, call it explicitly.
 
 ```javascript
 var SuperError = require('super-error');
@@ -69,6 +70,10 @@ err.code;    //=> 2
 err.message; //=> 'Invalid bar'
 
 throw err;
+
+var MyCustomError = SuperError.subclass('MyCustomError', function(message, properties) {
+  SuperError.call(this, 'Decorated ' + message, properties);
+});
 ```
 
 ## Exporting Error Classes

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var util = require('util');
 
-function SuperError(message, properties) {
+function SpecialConstructor() {
   if (!(this instanceof Error)) {
     throw new TypeError('SuperError called without new');
   }
@@ -8,6 +8,10 @@ function SuperError(message, properties) {
   if (typeof Error.captureStackTrace === 'function') {
     Error.captureStackTrace(this, this.constructor);
   }
+}
+
+function SuperError(message, properties) {
+  SpecialConstructor.call(this);
 
   if (typeof message === 'string') {
     this.message = message;
@@ -47,9 +51,11 @@ SuperError.subclass = function(exports, name, subclass_constructor) {
   var super_constructor = this;
 
   var constructor = function() {
-    super_constructor.apply(this, arguments);
     if (subclass_constructor) {
+      SpecialConstructor.call(this);
       subclass_constructor.apply(this, arguments);
+    } else {
+      super_constructor.apply(this, arguments);
     }
   };
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var util = require('util');
 
-function SpecialConstructor() {
+function BaseConstructor() {
   if (!(this instanceof Error)) {
     throw new TypeError('SuperError called without new');
   }
@@ -11,7 +11,7 @@ function SpecialConstructor() {
 }
 
 function SuperError(message, properties) {
-  SpecialConstructor.call(this);
+  BaseConstructor.call(this);
 
   if (typeof message === 'string') {
     this.message = message;
@@ -52,7 +52,7 @@ SuperError.subclass = function(exports, name, subclass_constructor) {
 
   var constructor = function() {
     if (subclass_constructor) {
-      SpecialConstructor.call(this);
+      BaseConstructor.call(this);
       subclass_constructor.apply(this, arguments);
     } else {
       super_constructor.apply(this, arguments);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-error",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Easily subclass errors",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -97,12 +97,28 @@ err = new ExportedComplexError(42, 'message');
 assert.equal(err.code, 42);
 assert.equal(err.message, '42message');
 
+var ObjectError = SuperError.subclass(
+  'ObjectError',
+  function(object) {
+    this.code = object.statusCode;
+    this.message = object.statusText;
+  }
+);
+
+err = new ObjectError({ statusCode: 418, statusText: 'I\'m a teapot' });
+assert.equal(err.code, 418);
+assert.equal(err.message, 'I\'m a teapot');
+assert.equal(err.statusCode, undefined, 'Should not have side effects from original constructor');
+assert.equal(err.statusText, undefined, 'Should not have side effects from original constructor');
+
 // SuperError.subclass(...).subclass
 
 var ParentError = SuperError.subclass('ParentError', function() {
+  SuperError.apply(this, arguments);
   this.parent_test = 'test';
 });
 var ChildError = ParentError.subclass('ChildError', function() {
+  ParentError.apply(this, arguments);
   this.child_test = 'test';
 });
 assert.equal(typeof ChildError, 'function');


### PR DESCRIPTION
Currently the parent constructors are always implicitly called with final constructor arguments, which causes conflicts and unexpected behaviors in case a child constructor expects different kind of arguments.

This commits changes this behavior by requiring a child constructor to explicitly call its parent constructor if needed.

However the base constructor also had code to ensure proper constructor instantiation and take care of the stack trace. This code should be executed regardless the parent constructor is explicitly called or not, thus the introduction of the SpecialConstructor to handle this: if a subclass constructor is given, only SpecialConstructor is called before.

Updated the tests and documentation accordingly, and bumped a major.

Closes #6.