### PR TITLE
Set constrcutor name

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,10 @@ SuperError.subclass = function(exports, name, subclass_constructor) {
     }
   };
 
-  constructor._name = name;
+  Object.defineProperty(constructor, 'name', {
+    value: name
+  });
+
   constructor.subclass = super_constructor.subclass;
 
   util.inherits(constructor, super_constructor);


### PR DESCRIPTION
Mainly to support [raven-node 2.2.1](https://github.com/getsentry/raven-node/commit/443ef262aa39f916e82395163b83a6bbefd351cb), which gets the error name from `err.constructor.name` (currently resulting in all Sentry errors being called `constructor`).

I'm not sure what `_name` was for and if it's ever used, this change might be breaking? Should we keep `_name` too?

Also we need to use `Object.definedProperty` because doing `constructor.name = name` doesn't work (it still reads the original name `constructor`), but looks like `Object.defineProperty` allows to override that.