### PR TITLE
Catch exceptions when Object.defineProperty is not allowed

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,9 +59,11 @@ SuperError.subclass = function(exports, name, subclass_constructor) {
     }
   };
 
-  Object.defineProperty(constructor, 'name', {
-    value: name
-  });
+  try {
+    Object.defineProperty(constructor, 'name', {
+      value: name
+    });
+  } catch (e) {};
 
   constructor.subclass = super_constructor.subclass;
 


### PR DESCRIPTION
On safari, you can't change the value of a readonly property:
![image](https://user-images.githubusercontent.com/4097282/55106400-34f7ed00-50a5-11e9-8c51-776543bd6832.png)

This PR will catch any exceptions when the above error happen.