### PR TITLE
Fix failing types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,12 @@
-declare namespace SuperError {
-  interface SuperErrorI {
-    name: string;
-    message: string;
-    [k: string]: any;
-  
-    new(...args: any[]): SuperError;
-  }
+interface SuperErrorI {
+  name: string;
+  message: string;
+  [k: string]: any;
+
+  new(...args: any[]): SuperError;
 }
 
-interface SuperError extends Error {
+declare class SuperError extends Error {
   name: string;
   message: string;
   [k: string]: any;
@@ -22,5 +20,4 @@ interface SuperError extends Error {
   causedBy(err: Error): this;
 }
 
-declare var SuperError: SuperError;
 export = SuperError;


### PR DESCRIPTION
## Overview

I'll be honest, I'm not 100% clear on what I'm doing here. However, the existing typings for super-error were causing my typechecks to fail in a dependant app so here is this PR.

Changes:
- Remove `SuperErrorI` from namespace (I don't see the advantage of this if it's only used in the typings file). 
- Switch the interface to a class declaration (I don't see how an interface can have subclasses).
- Export the class delcaration directly.

## Before changes:
```
yarn typecheck
yarn run v1.16.0
warning package.json: No license field
$ tsc
../super-error/index.d.ts:16:3 - error TS1070: 'static' modifier cannot appear on a type member.

16   static subclass(name: string): SuperErrorI;
     ~~~~~~

../super-error/index.d.ts:16:34 - error TS2304: Cannot find name 'SuperErrorI'.

16   static subclass(name: string): SuperErrorI;
                                    ~~~~~~~~~~~

../super-error/index.d.ts:17:3 - error TS1070: 'static' modifier cannot appear on a type member.

17   static subclass(exports: any, name: string): SuperErrorI;
     ~~~~~~

../super-error/index.d.ts:17:48 - error TS2304: Cannot find name 'SuperErrorI'.

17   static subclass(exports: any, name: string): SuperErrorI;
                                                  ~~~~~~~~~~~

../super-error/index.d.ts:18:3 - error TS1070: 'static' modifier cannot appear on a type member.

18   static subclass(exports: any, name: string, subclass_constructor: (this: SuperError, ...args: any[]) => void): SuperErrorI;
     ~~~~~~

../super-error/index.d.ts:18:114 - error TS2304: Cannot find name 'SuperErrorI'.

18   static subclass(exports: any, name: string, subclass_constructor: (this: SuperError, ...args: any[]) => void): SuperErrorI;
                                                                                                                    ~~~~~~~~~~~

../super-error/index.d.ts:19:3 - error TS1070: 'static' modifier cannot appear on a type member.

19   static subclass(name: string, subclass_constructor: (this: SuperError, ...args: any[]) => void): SuperErrorI;
     ~~~~~~

../super-error/index.d.ts:19:100 - error TS2304: Cannot find name 'SuperErrorI'.

19   static subclass(name: string, subclass_constructor: (this: SuperError, ...args: any[]) => void): SuperErrorI;
                                                                                                      ~~~~~~~~~~~


Found 8 errors.

error Command failed with exit code 1.
```

## After changes:
<img width="568" alt="image" src="https://user-images.githubusercontent.com/22868730/65700714-1bccfa80-e04e-11e9-858b-363aba8f8c19.png">

```
yarn typecheck
yarn run v1.16.0
warning package.json: No license field
$ tsc
✨  Done in 2.64s.
```