### PR TITLE
Add cause & rootCause to interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,8 @@ declare namespace SuperError {
 interface SuperError extends Error {
   name: string;
   message: string;
+  cause?: Error;
+  rootCause?: Error;
   [k: string]: any;
 
   subclass(name: string): SuperError.SuperErrorI;


### PR DESCRIPTION
Related to https://github.com/busbud/public-website/issues/12124
See https://busbud.slack.com/archives/CTNKWKHQF/p1622235152009600 for context

`cause` and `rootCause` may be defined if we use `causedBy()`: https://github.com/busbud/super-error/blob/0d5c011f3dd356335fc99cfe36539eb1dfbf03ed/index.js#L116-L121

Update the interface so TS clients can rely on it.