### PR TITLE
chore: replace `utils` by `inherits`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ node_modules
 .lock-wscript
 .nyc_output
 .eslintcache
+
+#IDE directories
+.idea
+

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var util = require('util');
+const inherits = require('inherits');
 
 function BaseConstructor() {
   if (!(this instanceof Error)) {
@@ -30,7 +30,7 @@ function SuperError(message, properties) {
     }
   }
 }
-util.inherits(SuperError, Error);
+inherits(SuperError, Error);
 SuperError.prototype.name = 'SuperError';
 
 SuperError.subclass = function(exports, name, subclass_constructor) {
@@ -97,7 +97,7 @@ function createConstructor(name, subclass_constructor, super_constructor) {
     };
   }
 
-  util.inherits(constructor, super_constructor);
+  inherits(constructor, super_constructor);
 
   if (typeof Object.setPrototypeOf === 'function') {
     Object.setPrototypeOf(constructor, super_constructor);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/busbud/super-error",
   "types": "./index.d.ts",
   "devDependencies": {
-    "busbud-lint": "1.7.0",
+    "busbud-lint": "1.9.0",
     "chai": "4.2.0",
     "mocha": "6.2.1",
     "nyc": "14.1.1"
@@ -41,5 +41,8 @@
     "extension": [
       ".js"
     ]
+  },
+  "dependencies": {
+    "inherits": "2.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,15 +249,15 @@ builtin-modules@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
   integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
-busbud-lint@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/busbud-lint/-/busbud-lint-1.7.0.tgz#8ab83aaf451e77bdcaa99a0b950785b55c6fe81f"
-  integrity sha512-JJnx0mt+RAumNj/HiviafVb3Cxrxo+5s71vByBF0xOikVuVdtY6VXz3WW/NHsC7RK03eBEjq2/wjnP47zqAgpw==
+busbud-lint@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/busbud-lint/-/busbud-lint-1.9.0.tgz#78144e4ba4c5adacee57704370c354a86f0b380a"
+  integrity sha512-/EYgmnQGw45zvK6nrxub4M8RfH5aK6SroAsGwZPJLssP2qs4FEXb2ijb8KEPCP3QIDCC6p5X1aaZDzMM7X2LIQ==
   dependencies:
     depcheck "0.8.3"
     docopt "0.6.2"
     eslint "6.1.0"
-    eslint-config-busbud "1.5.0"
+    eslint-config-busbud "1.6.0"
     npm-path "2.0.3"
 
 caching-transform@^3.0.2:
@@ -561,10 +561,10 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-busbud@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-busbud/-/eslint-config-busbud-1.5.0.tgz#e7b2b3494fb0fb15ecf5b4d875dfbd20bfe78e21"
-  integrity sha512-BRzB1orYO4KGK+jzopk9VOIJSew+6Wm0+IMfhE6L34yNmU8DwouSG9JF3Ki314SLNu+sg06i4reFTwHNfuqGJA==
+eslint-config-busbud@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-busbud/-/eslint-config-busbud-1.6.0.tgz#6e9d13bdfab3ebb48fc533964d17568db5061fb1"
+  integrity sha512-TL2XSlwB4VMYoCYE5XUQCfyx1YE2uuqlEseLr6f8vZ2J7TF/5xiMKRs0djnNPd7dx/a3rm/0h2B14iPBv8SjgA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "1.13.0"
     "@typescript-eslint/parser" "1.13.0"
@@ -1080,7 +1080,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==


### PR DESCRIPTION
SuperError is actually also used in browser,
and:
  1. in pubweb it was working by chance, because another package was needing utils. So better to import explicitly the dependency
  2. because of the way it was used, tree shaking was basically impossible.
  3. `utils` polyfill for browser is importing a ton of useless things... so if we're only using inherits, the easiest fix was to import explicitly inherit and use it directly

Once everything is one, I expect a gain of ~15Kb on the common module used by the landing pages